### PR TITLE
Fixed change of keyword_result object instead of its status

### DIFF
--- a/yandex_images_download/downloader.py
+++ b/yandex_images_download/downloader.py
@@ -336,7 +336,7 @@ class YandexImagesDownloader():
         response = self.get_response()
 
         if not (response.reason == "OK"):
-            keyword_result = "fail"
+            keyword_result.status = "fail"
             keyword_result.message = (
                 "Failed to fetch a search page."
                 f" url: {YandexImagesDownloader.MAIN_URL},"


### PR DESCRIPTION
When response is not OK code breaks because of setting message property for the string object